### PR TITLE
[FEATURE] API 응답 정규화 & Custom Exception

### DIFF
--- a/src/main/java/com/likelion/commit/gloabal/exception/CustomException.java
+++ b/src/main/java/com/likelion/commit/gloabal/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.likelion.commit.gloabal.exception;
+
+
+import com.likelion.commit.gloabal.response.status.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public CustomException(BaseErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/likelion/commit/gloabal/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/commit/gloabal/exception/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package com.likelion.commit.gloabal.exception;
+
+
+import com.likelion.commit.gloabal.response.ApiResponse;
+import com.likelion.commit.gloabal.response.ErrorCode;
+import com.likelion.commit.gloabal.response.status.BaseErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // @Valid 유효성 검사를 실패 시
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException ex
+    ) {
+        Map<String, String> failedValidations = new HashMap<>();
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+        fieldErrors.forEach(error -> failedValidations.put(error.getField(), error.getDefaultMessage()));
+        ApiResponse<Map<String, String>> errorResponse = ApiResponse.onFailure(
+                ErrorCode.VALIDATION_FAILED.getCode(),
+                ErrorCode.VALIDATION_FAILED.getMessage(),
+                failedValidations);
+        return ResponseEntity.status(ex.getStatusCode()).body(errorResponse);
+    }
+
+    // Custom 예외에 대한 처리
+    @ExceptionHandler({CustomException.class})
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+        log.warn("[WARNING] Custom Exception : {}", e.getErrorCode());
+        BaseErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.
+                status(errorCode.getHttpStatus())
+                .body(errorCode.getErrorResponse());
+    }
+
+    // 그 외의 정의되지 않은 모든 예외 처리 (디버깅을 위해 일시 무효화)
+//    @ExceptionHandler({Exception.class})
+//    public ResponseEntity<ApiResponse<String>> handleAllException(Exception e) {
+//        log.error("[WARNING] Internal Server Error : {} ", e.getMessage());
+//        BaseErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR_500;
+//        ApiResponse<String> errorResponse = ApiResponse.onFailure(
+//                errorCode.getCode(),
+//                errorCode.getMessage(),
+//                e.getMessage()
+//        );
+//        return ResponseEntity
+//                .status(errorCode.getHttpStatus())
+//                .body(errorResponse);
+//    }
+
+}

--- a/src/main/java/com/likelion/commit/gloabal/response/ApiResponse.java
+++ b/src/main/java/com/likelion/commit/gloabal/response/ApiResponse.java
@@ -1,0 +1,48 @@
+package com.likelion.commit.gloabal.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"code", "message", "result"})
+public class ApiResponse<T> {
+
+    // HTTP 상태 코드나 사용자 정의 코드
+    private final String code;
+
+    // API 요청에 대한 설명이나 상태 메시지
+    private final String message;
+
+    // result 값은 null이 아닐 때만 응답에 포함시킨다.
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+
+    // 결과 데이터
+    private T result;
+
+    // 성공한 경우
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(String.valueOf(HttpStatus.OK.value()), HttpStatus.OK.getReasonPhrase(), result);
+    }
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(HttpStatus status, T result) {
+        return new ApiResponse<>(String.valueOf(status.value()), status.getReasonPhrase(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T result) {
+        return new ApiResponse<>(code, message, result);
+    }
+
+    // 실패한 경우 응답 생성 (데이터 없음)
+    public static <T> ApiResponse<T> onFailure(String statusCode, String message) {
+        return new ApiResponse<>(statusCode, message, null);
+    }
+
+}

--- a/src/main/java/com/likelion/commit/gloabal/response/ErrorCode.java
+++ b/src/main/java/com/likelion/commit/gloabal/response/ErrorCode.java
@@ -1,0 +1,51 @@
+package com.likelion.commit.gloabal.response;
+
+
+import com.likelion.commit.gloabal.response.status.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements BaseErrorCode {
+
+    // 일반적인 ERROR 응답
+    BAD_REQUEST_400(HttpStatus.BAD_REQUEST,
+            "COMMON400",
+            HttpStatus.BAD_REQUEST.getReasonPhrase()),
+    UNAUTHORIZED_401(HttpStatus.UNAUTHORIZED,
+            "COMMON401",
+            HttpStatus.UNAUTHORIZED.getReasonPhrase()),
+    FORBIDDEN_403(HttpStatus.FORBIDDEN,
+            "COMMON403",
+            HttpStatus.FORBIDDEN.getReasonPhrase()),
+    NOT_FOUND_404(HttpStatus.NOT_FOUND,
+            "COMMON404",
+            HttpStatus.NOT_FOUND.getReasonPhrase()),
+    INTERNAL_SERVER_ERROR_500(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "COMMON500",
+            HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase()),
+
+    // 유효성 검사
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALID400_0", "잘못된 파라미터 입니다."),
+
+    // 데이터 관련 에러
+    NO_USER_MEDIAN_REGISTERED(HttpStatus.NOT_FOUND, "USER404_0", "사용자 설정값이 존재하지 않습니다."),
+    NO_USER_DATA_REGISTERED(HttpStatus.NOT_FOUND, "USER404_1", "사용자 데이터 값이 존재하지 않습니다."),
+
+    //통신 과정 에러
+    COMMUNICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500_1", "통신 과정에서 문제가 발생했습니다."),
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ApiResponse<Void> getErrorResponse() {
+        return ApiResponse.onFailure(code, message);
+    }
+}

--- a/src/main/java/com/likelion/commit/gloabal/response/status/BaseErrorCode.java
+++ b/src/main/java/com/likelion/commit/gloabal/response/status/BaseErrorCode.java
@@ -1,0 +1,15 @@
+package com.likelion.commit.gloabal.response.status;
+
+import com.likelion.commit.gloabal.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+
+    HttpStatus getHttpStatus();
+
+    String getCode();
+
+    String getMessage();
+
+    ApiResponse<Void> getErrorResponse();
+}


### PR DESCRIPTION
# Title
API 응답 정규화 & Custom Exception

# Issue
- resolves #7 

# Contents

### API 응답 정규화 진행 
- API 응답에 ApiResponse 클래스 사용
- 사용 예시
```java

@GetMapping("/test")
public ApiResponse<TestResponse> apiTest( String param) {
    //...
    return ApiResponse.onSuccess(HttpStatus.OK, "조회 완료");
}
```

### Custom Exception 관리 
- ErrorCode에 에러 명시 후 CustomException 던지기
- 사용 예시

1. ErrorCode에 다음을 추가

```java
USER_ERROR(HttpStatus.NOT_FOUND , "USER400", "사용자를 찾지 못했습니다."),
```

2. 서비스 로직에서 Custome Exception을 생성하여 throw
```java
userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.USER_ERROR));
```