### PR TITLE
✨feat :일정 API

### DIFF
--- a/src/main/java/com/likelion/commit/CommitApplication.java
+++ b/src/main/java/com/likelion/commit/CommitApplication.java
@@ -2,8 +2,10 @@ package com.likelion.commit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CommitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/likelion/commit/controller/PlanController.java
+++ b/src/main/java/com/likelion/commit/controller/PlanController.java
@@ -1,0 +1,181 @@
+package com.likelion.commit.controller;
+
+
+import com.likelion.commit.dto.request.*;
+import com.likelion.commit.dto.response.PlanResponseDto;
+import com.likelion.commit.dto.response.TimeTableResponseDto;
+import com.likelion.commit.gloabal.response.ApiResponse;
+import com.likelion.commit.gloabal.response.ErrorCode;
+import com.likelion.commit.service.PlanService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plan")
+public class PlanController {
+
+    private final PlanService planService;
+
+    @PostMapping("/create")
+    public ApiResponse<List<PlanResponseDto>> createPlans(@RequestParam String email,
+                                                          @RequestBody List<CreatePlanRequestDto> createPlanRequestDtoList) {
+        try {
+            List<PlanResponseDto> responseDtos = planService.createPlans(email, createPlanRequestDtoList);
+            return ApiResponse.onSuccess(HttpStatus.CREATED, responseDtos);
+        } catch (Exception e) {
+            log.error("Error creating plans: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @PutMapping("/update")
+    public ApiResponse<String> updatePlan(@RequestParam String email,
+                                          @RequestBody List<UpdatePlanRequestDto> updatePlanRequestDtos) {
+        try {
+            planService.updatePlans(email, updatePlanRequestDtos);
+            return ApiResponse.onSuccess(HttpStatus.OK, "일정 수정에 설정했습니다.");
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "일정을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            log.error("Error updating plans: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @DeleteMapping("/delete")
+    public ApiResponse<String> deletePlan(@RequestParam String email,
+                                          @RequestBody List<DeletePlanRequestDto> deletePlanRequestDtos) {
+        try {
+            planService.deletePlans(email, deletePlanRequestDtos);
+            return ApiResponse.onSuccess(HttpStatus.OK, "일정 삭제 완료했습니다.");
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "일정을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            log.error("Error deleting plans: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @PostMapping("/complete/{planId}")
+    public ApiResponse<String> completePlan(@RequestParam String email, @PathVariable Long planId,
+                                            @RequestBody PlanTimeRequestDto planTimeRequestDto) {
+        try {
+            planService.completePlan(email, planId, planTimeRequestDto);
+            return ApiResponse.onSuccess(HttpStatus.OK, "일정 완료 했습니다. planId :" + planId);
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "일정을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            log.error("Error completing plan: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @PostMapping("/cancel/{planId}")
+    public ApiResponse<String> cancelPlan(@RequestParam String email, @PathVariable Long planId) {
+        try {
+            planService.cancelPlan(email, planId);
+            return ApiResponse.onSuccess(HttpStatus.OK, "일정을 취소 했습니다. planId :" + planId);
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "일정을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            log.error("Error canceling plan: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @PostMapping("/delay/{planId}")
+    public ApiResponse<String> delayPlan(@RequestParam String email, @PathVariable Long planId,
+                                         @RequestBody DelayPlanRequestDto delayPlanRequestDto) {
+        try {
+            planService.delayPlan(email, planId, delayPlanRequestDto);
+            return ApiResponse.onSuccess(HttpStatus.OK, "일정 미루기를 완료 했습니다. planId :" + planId);
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "일정을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            log.error("Error delaying plan: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @PutMapping("/time/{planId}")
+    public ApiResponse<String> updateAddedTime(@RequestParam String email, @PathVariable Long planId,
+                                               @RequestBody PlanTimeRequestDto planTimeRequestDto) {
+        try {
+            planService.updateAddedTime(email, planId, planTimeRequestDto);
+            return ApiResponse.onSuccess(HttpStatus.OK, "일정의 시간을 수정했습니다.");
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "일정을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            log.error("Error updating added time: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+//    @PutMapping("/timetable/time/{fixedPlanId}")
+//    public ApiResponse<String> updateFixedTime(@RequestParam String email, @PathVariable Long fixedPlanId,
+//                                               @RequestBody PlanTimeRequestDto planTimeRequestDto) {
+//        try {
+//            planService.updateFixedTime(email, fixedPlanId, planTimeRequestDto);
+//            return ApiResponse.onSuccess(HttpStatus.OK, "일정의 시간을 수정했습니다.");
+//        } catch (NoSuchElementException e) {
+//            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "일정을 찾을 수 없습니다.");
+//        } catch (Exception e) {
+//            log.error("Error updating fixed time: ", e);
+//            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+//        }
+//    }
+
+    @GetMapping("/date")
+    public ApiResponse<List<PlanResponseDto>> getPlan(@RequestParam String email, @RequestBody PlanDateRequestDto planDateRequestDto) {
+        try {
+            List<PlanResponseDto> plans = planService.getPlans(email, planDateRequestDto);
+            return ApiResponse.onSuccess(HttpStatus.OK, plans);
+        } catch (Exception e) {
+            log.error("Error retrieving plans: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @GetMapping("/timetable")
+    public ApiResponse<List<TimeTableResponseDto>> getTimeTable(@RequestParam String email, @RequestBody PlanDateRequestDto planDateRequestDto) {
+        try {
+            List<TimeTableResponseDto> timeTable = planService.getTimeTable(email, planDateRequestDto);
+            return ApiResponse.onSuccess(HttpStatus.OK, timeTable);
+        } catch (Exception e) {
+            log.error("Error retrieving timetable: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @GetMapping("/upcoming")
+    public ApiResponse<List<PlanResponseDto>> getUpcomingPlans(@RequestParam String email) {
+        try {
+            List<PlanResponseDto> upcomingPlans = planService.getUpcomingPlans(email);
+            return ApiResponse.onSuccess(HttpStatus.OK, upcomingPlans);
+        } catch (Exception e) {
+            log.error("Error retrieving upcoming plans: ", e);
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    @PostMapping("/calendar/create")
+    public ApiResponse<List<PlanResponseDto>> createCalendarPlans(@RequestParam String email,
+                                                                  @RequestBody CalendarPlanRequestDto calendarPlanRequestDto){
+        try {
+            List<PlanResponseDto> planResponseDtos = planService.createCalendarPlans(email, calendarPlanRequestDto);
+            return ApiResponse.onSuccess(HttpStatus.OK, planResponseDtos);
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.onFailure(String.valueOf(HttpStatus.BAD_REQUEST.value()), e.getMessage());
+        } catch (Exception e) {
+            return ApiResponse.onFailure(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR.value()), "서버에서 오류가 발생했습니다.");
+        }
+    }
+}
+

--- a/src/main/java/com/likelion/commit/controller/UserController.java
+++ b/src/main/java/com/likelion/commit/controller/UserController.java
@@ -1,16 +1,23 @@
 package com.likelion.commit.controller;
 
-import com.likelion.commit.dto.CreateRuleSetRequestDto;
-import com.likelion.commit.dto.CreateUserRequestDto;
-import com.likelion.commit.dto.UpdatePasswordRequestDto;
-import com.likelion.commit.dto.UpdateRuleSetRequestDto;
+import com.likelion.commit.dto.request.CreateRuleSetRequestDto;
+import com.likelion.commit.dto.request.CreateUserRequestDto;
+import com.likelion.commit.dto.request.UpdatePasswordRequestDto;
+import com.likelion.commit.dto.request.UpdateRuleSetRequestDto;
+import com.likelion.commit.dto.response.RuleSetResponseDto;
+import com.likelion.commit.dto.response.UserResponseDto;
+import com.likelion.commit.gloabal.response.ApiResponse;
+import com.likelion.commit.gloabal.response.ErrorCode;
 import com.likelion.commit.service.RuleSetService;
 import com.likelion.commit.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Slf4j
 @RestController
@@ -22,57 +29,106 @@ public class UserController {
     private final RuleSetService ruleSetService;
 
     @PostMapping("/create")
-    public ResponseEntity<?> createUser(@RequestBody CreateUserRequestDto createUserRequestDto){
-        long userId = userService.createUser(createUserRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다. userId: " + userId);
+    public ApiResponse<Map<String, Long>> createUser(@RequestBody CreateUserRequestDto createUserRequestDto) {
+        try {
+            long userId = userService.createUser(createUserRequestDto);
+
+            // 결과 데이터 생성
+            Map<String, Long> result = new HashMap<>();
+            result.put("userId", userId);
+
+            return ApiResponse.onSuccess(HttpStatus.CREATED, result);
+        } catch (Exception e) {
+            return ApiResponse.onFailure(
+                    ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(),
+                    "서버에서 오류가 발생했습니다."
+            );
+        }
     }
 
-    // 파라미터에서 String email은 인가적용 시 교체
     @PutMapping("/updatePassword")
-    public ResponseEntity<?> updatePassword(@RequestParam("email") String email, @RequestBody UpdatePasswordRequestDto updatePasswordRequestDto){
-        userService.updatePassword(email, updatePasswordRequestDto);
-        return ResponseEntity.status(HttpStatus.OK).body("비밀번호 변경이 완료되었습니다.");
+    public ApiResponse<String> updatePassword(@RequestParam("email") String email,
+                                              @RequestBody UpdatePasswordRequestDto updatePasswordRequestDto) {
+        try {
+            userService.updatePassword(email, updatePasswordRequestDto);
+            return ApiResponse.onSuccess(HttpStatus.OK, "비밀번호 변경이 완료되었습니다.");
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "사용자를 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
     }
-
 
     @DeleteMapping("/delete")
-    public ResponseEntity<?> deleteUser(@RequestParam("email") String email){
-        userService.deleteUser(email);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body("회원 탈퇴가 완료되었습니다.");
+    public ApiResponse<String> deleteUser(@RequestParam("email") String email) {
+        try {
+            userService.deleteUser(email);
+            return ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "회원 탈퇴가 완료되었습니다.");
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "사용자를 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
     }
 
     @GetMapping("")
-    public ResponseEntity<?> getUser(@RequestParam("email") String email){
-        return ResponseEntity.ok(userService.getUser(email));
+    public ApiResponse<UserResponseDto> getUser(@RequestParam("email") String email) {
+        try {
+            UserResponseDto user = userService.getUser(email);
+            return ApiResponse.onSuccess(HttpStatus.OK, user);
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "사용자를 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
     }
-
-
-
 
     // RuleSet 부분
 
     @PostMapping("/ruleSet/create")
-    public ResponseEntity<?> createRuleSet(@RequestParam("email") String email,
-                                           @RequestBody CreateRuleSetRequestDto createRuleSetRequestDto){
-        long ruleSetId = ruleSetService.createRuleSet(email, createRuleSetRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body("커스텀 규칙이 생성되었습니다. 규칙id: " + ruleSetId);
-    }
+    public ApiResponse<Map<String, Long>> createRuleSet(@RequestParam("email") String email,
+                                                        @RequestBody CreateRuleSetRequestDto createRuleSetRequestDto) {
+        try {
+            long ruleSetId = ruleSetService.createRuleSet(email, createRuleSetRequestDto);
 
+            Map<String, Long> result = new HashMap<>();
+            result.put("ruleSetId", ruleSetId);
+
+            return ApiResponse.onSuccess(HttpStatus.CREATED, result);
+        } catch (Exception e) {
+            return ApiResponse.onFailure(
+                    ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(),
+                    "서버에서 오류가 발생했습니다."
+            );
+        }
+    }
 
 
     @GetMapping("/ruleSet")
-    public ResponseEntity<?> getRuleSet(@RequestParam("email") String email){
-        return ResponseEntity.ok(ruleSetService.getRuleSet(email));
+    public ApiResponse<RuleSetResponseDto> getRuleSet(@RequestParam("email") String email) {
+        try {
+            RuleSetResponseDto ruleSet = ruleSetService.getRuleSet(email);
+            return ApiResponse.onSuccess(HttpStatus.OK, ruleSet);
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "규칙을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
     }
 
     @PutMapping("/ruleSet/update")
-    public ResponseEntity<?> updateRuleSet(@RequestParam("email") String email,
-                                           @RequestBody UpdateRuleSetRequestDto updateRuleSetRequestDto){
-        ruleSetService.updateRuleSet(email, updateRuleSetRequestDto);
-        return ResponseEntity.status(HttpStatus.OK).body("커스텀 규칙이 수정되었습니다.");
+    public ApiResponse<String> updateRuleSet(@RequestParam("email") String email,
+                                             @RequestBody UpdateRuleSetRequestDto updateRuleSetRequestDto) {
+        try {
+            ruleSetService.updateRuleSet(email, updateRuleSetRequestDto);
+            return ApiResponse.onSuccess(HttpStatus.OK, "커스텀 규칙이 수정되었습니다.");
+        } catch (NoSuchElementException e) {
+            return ApiResponse.onFailure(ErrorCode.NO_USER_DATA_REGISTERED.getCode(), "규칙을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR_500.getCode(), "서버에서 오류가 발생했습니다.");
+        }
     }
-
-
 }
+
 
 

--- a/src/main/java/com/likelion/commit/dto/request/CalendarPlanRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/CalendarPlanRequestDto.java
@@ -1,0 +1,19 @@
+package com.likelion.commit.dto.request;
+
+import com.likelion.commit.entity.PlanType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CalendarPlanRequestDto {
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String content;
+    private PlanType type;
+}

--- a/src/main/java/com/likelion/commit/dto/request/CreatePlanRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/CreatePlanRequestDto.java
@@ -1,0 +1,29 @@
+package com.likelion.commit.dto.request;
+
+
+import com.likelion.commit.entity.Plan;
+import com.likelion.commit.entity.PlanType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CreatePlanRequestDto {
+    public LocalDate date;
+    public String content;
+    public int priority;
+    public PlanType type;
+
+    public Plan toEntity(){
+        return Plan.builder()
+                .date(date)
+                .content(content)
+                .priority(priority)
+                .type(type)
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/commit/dto/request/CreateRuleSetRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/CreateRuleSetRequestDto.java
@@ -1,4 +1,4 @@
-package com.likelion.commit.dto;
+package com.likelion.commit.dto.request;
 
 
 import com.likelion.commit.entity.RuleSet;
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class UpdateRuleSetRequestDto {
+public class CreateRuleSetRequestDto {
+
     public String WLBalance;
     public String sleepTime;
     public String exerciseTime;

--- a/src/main/java/com/likelion/commit/dto/request/CreateUserRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/CreateUserRequestDto.java
@@ -1,4 +1,4 @@
-package com.likelion.commit.dto;
+package com.likelion.commit.dto.request;
 
 
 import com.likelion.commit.entity.User;

--- a/src/main/java/com/likelion/commit/dto/request/DelayPlanRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/DelayPlanRequestDto.java
@@ -1,0 +1,15 @@
+package com.likelion.commit.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class DelayPlanRequestDto {
+    public LocalDate delayedDate;
+}

--- a/src/main/java/com/likelion/commit/dto/request/DeletePlanRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/DeletePlanRequestDto.java
@@ -1,4 +1,5 @@
-package com.likelion.commit.dto;
+package com.likelion.commit.dto.request;
+
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class UpdatePasswordRequestDto {
-    public String currentPassword;
-    public String newPassword;
+public class DeletePlanRequestDto {
+    public Long planId;
 }

--- a/src/main/java/com/likelion/commit/dto/request/DiaryDateRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/DiaryDateRequestDto.java
@@ -1,0 +1,14 @@
+package com.likelion.commit.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class DiaryDateRequestDto {
+    public LocalDate date;
+}

--- a/src/main/java/com/likelion/commit/dto/request/DiaryRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/DiaryRequestDto.java
@@ -1,0 +1,25 @@
+package com.likelion.commit.dto.request;
+
+
+import com.likelion.commit.entity.Diary;
+import com.likelion.commit.entity.Plan;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class DiaryRequestDto {
+    public LocalDate date;
+    public String content;
+
+    public Diary toEntity(){
+        return Diary.builder()
+                .date(date)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/commit/dto/request/FinishRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/FinishRequestDto.java
@@ -1,0 +1,24 @@
+package com.likelion.commit.dto.request;
+
+
+import com.likelion.commit.entity.Diary;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+public class FinishRequestDto {
+    public LocalDate date;
+    public String content;
+
+    public Diary toEntity(){
+        return Diary.builder()
+                .date(date)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/commit/dto/request/MonthPlanRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/MonthPlanRequestDto.java
@@ -1,0 +1,13 @@
+package com.likelion.commit.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+public class MonthPlanRequestDto {
+    String yearMonth;
+}

--- a/src/main/java/com/likelion/commit/dto/request/PlanDateRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/PlanDateRequestDto.java
@@ -1,0 +1,15 @@
+package com.likelion.commit.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class PlanDateRequestDto {
+    public LocalDate date;
+}

--- a/src/main/java/com/likelion/commit/dto/request/PlanTimeRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/PlanTimeRequestDto.java
@@ -5,12 +5,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class PlanTimeRequestDto {
-    public LocalDateTime startTime;
-    public LocalDateTime endTime;
+    public LocalTime startTime;
+    public LocalTime endTime;
 
 }

--- a/src/main/java/com/likelion/commit/dto/request/PlanTimeRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/PlanTimeRequestDto.java
@@ -1,0 +1,16 @@
+package com.likelion.commit.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class PlanTimeRequestDto {
+    public LocalDateTime startTime;
+    public LocalDateTime endTime;
+
+}

--- a/src/main/java/com/likelion/commit/dto/request/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/UpdatePasswordRequestDto.java
@@ -1,0 +1,13 @@
+package com.likelion.commit.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UpdatePasswordRequestDto {
+    public String currentPassword;
+    public String newPassword;
+}

--- a/src/main/java/com/likelion/commit/dto/request/UpdatePlanRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/UpdatePlanRequestDto.java
@@ -1,0 +1,16 @@
+package com.likelion.commit.dto.request;
+
+import com.likelion.commit.entity.PlanType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UpdatePlanRequestDto {
+    public Long planId;
+    public String content;
+    public int priority;
+    public PlanType planType;
+}

--- a/src/main/java/com/likelion/commit/dto/request/UpdateRuleSetRequestDto.java
+++ b/src/main/java/com/likelion/commit/dto/request/UpdateRuleSetRequestDto.java
@@ -1,4 +1,4 @@
-package com.likelion.commit.dto;
+package com.likelion.commit.dto.request;
 
 
 import com.likelion.commit.entity.RuleSet;
@@ -9,8 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class CreateRuleSetRequestDto {
-
+public class UpdateRuleSetRequestDto {
     public String WLBalance;
     public String sleepTime;
     public String exerciseTime;

--- a/src/main/java/com/likelion/commit/dto/response/DiaryResponseDto.java
+++ b/src/main/java/com/likelion/commit/dto/response/DiaryResponseDto.java
@@ -1,0 +1,25 @@
+package com.likelion.commit.dto.response;
+
+
+import com.likelion.commit.entity.Diary;
+import com.likelion.commit.entity.RuleSet;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class DiaryResponseDto {
+    public Long diaryId;
+    public String content;
+
+    public static DiaryResponseDto from(Diary diary){
+        return DiaryResponseDto.builder()
+                .diaryId(diary.getId())
+                .content(diary.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/commit/dto/response/PlanResponseDto.java
+++ b/src/main/java/com/likelion/commit/dto/response/PlanResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,8 +25,8 @@ public class PlanResponseDto {
     private PlanType type;
     private LocalDate date;
     private boolean isComplete;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
+    private LocalTime startTime;
+    private LocalTime endTime;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private PlanStatus status;

--- a/src/main/java/com/likelion/commit/dto/response/PlanResponseDto.java
+++ b/src/main/java/com/likelion/commit/dto/response/PlanResponseDto.java
@@ -1,0 +1,66 @@
+package com.likelion.commit.dto.response;
+
+import com.likelion.commit.entity.Plan;
+import com.likelion.commit.entity.PlanStatus;
+import com.likelion.commit.entity.PlanType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class PlanResponseDto {
+    private Long planId;
+    private String content;
+    private int priority;
+    private PlanType type;
+    private LocalDate date;
+    private boolean isComplete;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private PlanStatus status;
+    private boolean isDelayed;
+    private Long childPlan;
+    private Long userId;
+
+
+    public PlanResponseDto(Plan plan) {
+        this.planId = plan.getId();
+        this.date = plan.getDate();
+        this.isComplete = plan.isComplete();
+        this.startTime = plan.getStartTime();
+        this.endTime = plan.getEndTime();
+        this.priority = plan.getPriority();
+        this.createdAt = plan.getCreatedAt();
+        this.updatedAt = plan.getUpdatedAt();
+        this.content = plan.getContent();
+        this.status = plan.getStatus();
+        this.isDelayed = plan.isDelayed();
+        this.childPlan = plan.getChildPlan();
+        this.type = plan.getType();
+        this.userId = plan.getUser().getId();
+
+    }
+
+    // Plan -> PlanResponseDto
+    public static PlanResponseDto from(Plan plan) {
+        return new PlanResponseDto(plan);
+    }
+
+    // List<Plan> -> <PlanResponseDto>
+    public static List<PlanResponseDto> from(List<Plan> plans) {
+        return plans.stream()
+                .map(PlanResponseDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/likelion/commit/dto/response/RuleSetResponseDto.java
+++ b/src/main/java/com/likelion/commit/dto/response/RuleSetResponseDto.java
@@ -1,4 +1,4 @@
-package com.likelion.commit.dto;
+package com.likelion.commit.dto.response;
 
 
 import com.likelion.commit.entity.RuleSet;

--- a/src/main/java/com/likelion/commit/dto/response/TimeTableResponseDto.java
+++ b/src/main/java/com/likelion/commit/dto/response/TimeTableResponseDto.java
@@ -1,0 +1,26 @@
+package com.likelion.commit.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TimeTableResponseDto {
+    private Long planId;
+//    private Long fixedPlanId;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private boolean isWeekend;
+    private String content;
+    private Long userId;
+    private boolean isFixed;
+    private int priority;
+
+}

--- a/src/main/java/com/likelion/commit/dto/response/TimeTableResponseDto.java
+++ b/src/main/java/com/likelion/commit/dto/response/TimeTableResponseDto.java
@@ -1,26 +1,63 @@
 package com.likelion.commit.dto.response;
 
 
+import com.likelion.commit.entity.FixedPlan;
+import com.likelion.commit.entity.TimeTable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class TimeTableResponseDto {
-    private Long planId;
-//    private Long fixedPlanId;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
-    private boolean isWeekend;
-    private String content;
-    private Long userId;
-    private boolean isFixed;
-    private int priority;
+
+    public List<TimeTableResponse> fixedPlans;
+    public List<TimeTableResponse> plans;
+
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TimeTableResponse {
+        public Long planId;
+        //    private Long fixedPlanId;
+        public LocalTime startTime;
+        public LocalTime endTime;
+        public String content;
+        public boolean isFixed;
+        public int priority;
+
+        public static  TimeTableResponse from(FixedPlan fixedPlan) {
+            return TimeTableResponse.builder()
+                    .planId(fixedPlan.getId())
+                    .startTime(fixedPlan.getStartTime())
+                    .endTime(fixedPlan.getEndTime())
+                    .content(fixedPlan.getContent())
+                    .isFixed(true)
+                    .priority(0)
+                    .build();
+
+        }
+
+        public static TimeTableResponse from(TimeTable timeTable) {
+            return TimeTableResponse.builder()
+                    .planId(timeTable.getPlanId())
+                    .startTime(timeTable.getStartTime())
+                    .endTime(timeTable.getEndTime())
+                    .content(timeTable.getContent())
+                    .isFixed(timeTable.isFixed())
+                    .priority(timeTable.getPriority())
+                    .build();
+        }
+    }
 
 }

--- a/src/main/java/com/likelion/commit/dto/response/UserResponseDto.java
+++ b/src/main/java/com/likelion/commit/dto/response/UserResponseDto.java
@@ -1,4 +1,4 @@
-package com.likelion.commit.dto;
+package com.likelion.commit.dto.response;
 
 
 import com.likelion.commit.entity.User;

--- a/src/main/java/com/likelion/commit/entity/Diary.java
+++ b/src/main/java/com/likelion/commit/entity/Diary.java
@@ -1,8 +1,32 @@
 package com.likelion.commit.entity;
 
 
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "diary")
 public class Diary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate date;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+
 }

--- a/src/main/java/com/likelion/commit/entity/Diary.java
+++ b/src/main/java/com/likelion/commit/entity/Diary.java
@@ -1,0 +1,8 @@
+package com.likelion.commit.entity;
+
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Diary {
+}

--- a/src/main/java/com/likelion/commit/entity/FixedPlan.java
+++ b/src/main/java/com/likelion/commit/entity/FixedPlan.java
@@ -1,0 +1,36 @@
+package com.likelion.commit.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "fixedPlan")
+public class FixedPlan {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    private boolean isWeekend;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+}

--- a/src/main/java/com/likelion/commit/entity/FixedPlan.java
+++ b/src/main/java/com/likelion/commit/entity/FixedPlan.java
@@ -1,6 +1,7 @@
 package com.likelion.commit.entity;
 
 
+import com.likelion.commit.dto.response.TimeTableResponseDto;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -33,4 +34,5 @@ public class FixedPlan {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
     private User user;
+
 }

--- a/src/main/java/com/likelion/commit/entity/Plan.java
+++ b/src/main/java/com/likelion/commit/entity/Plan.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @Setter
@@ -29,9 +30,9 @@ public class Plan {
 
     private boolean isComplete;
 
-    private LocalDateTime startTime;
+    private LocalTime startTime;
 
-    private LocalDateTime endTime;
+    private LocalTime endTime;
 
     private int priority;
 

--- a/src/main/java/com/likelion/commit/entity/Plan.java
+++ b/src/main/java/com/likelion/commit/entity/Plan.java
@@ -1,0 +1,67 @@
+package com.likelion.commit.entity;
+
+
+import com.likelion.commit.dto.request.UpdatePlanRequestDto;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "plan")
+public class Plan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate date;
+
+    private boolean isComplete;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    private int priority;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private PlanStatus status;
+
+    private boolean isDelayed;
+
+    private Long childPlan;
+
+    @Enumerated(EnumType.STRING)
+    private PlanType type;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+
+    public void update(UpdatePlanRequestDto updatePlanRequestDto){
+        this.content = updatePlanRequestDto.getContent();
+        this.priority = updatePlanRequestDto.getPriority();
+        this.type = updatePlanRequestDto.getPlanType();
+    }
+}

--- a/src/main/java/com/likelion/commit/entity/PlanStatus.java
+++ b/src/main/java/com/likelion/commit/entity/PlanStatus.java
@@ -1,0 +1,5 @@
+package com.likelion.commit.entity;
+
+public enum PlanStatus {
+    COMPLETE, DELAYED, CANCELED
+}

--- a/src/main/java/com/likelion/commit/entity/PlanType.java
+++ b/src/main/java/com/likelion/commit/entity/PlanType.java
@@ -1,0 +1,5 @@
+package com.likelion.commit.entity;
+
+public enum PlanType {
+    LIFE, WORK, EXERCISE
+}

--- a/src/main/java/com/likelion/commit/entity/RuleSet.java
+++ b/src/main/java/com/likelion/commit/entity/RuleSet.java
@@ -1,7 +1,7 @@
 package com.likelion.commit.entity;
 
 
-import com.likelion.commit.dto.UpdateRuleSetRequestDto;
+import com.likelion.commit.dto.request.UpdateRuleSetRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/likelion/commit/entity/TimeTable.java
+++ b/src/main/java/com/likelion/commit/entity/TimeTable.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @Setter
@@ -23,13 +24,19 @@ public class TimeTable {
 
     private LocalDate date;
 
-    private LocalDateTime startTime;
+    private LocalTime startTime;
 
-    private LocalDateTime endTime;
+    private LocalTime endTime;
 
     private int priority;
 
     private String content;
 
     private boolean isFixed;
+
+    private Long planId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
 }

--- a/src/main/java/com/likelion/commit/entity/TimeTable.java
+++ b/src/main/java/com/likelion/commit/entity/TimeTable.java
@@ -1,0 +1,35 @@
+package com.likelion.commit.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "timetable")
+public class TimeTable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate date;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    private int priority;
+
+    private String content;
+
+    private boolean isFixed;
+}

--- a/src/main/java/com/likelion/commit/entity/User.java
+++ b/src/main/java/com/likelion/commit/entity/User.java
@@ -4,6 +4,8 @@ package com.likelion.commit.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -31,6 +33,11 @@ public class User {
     private RuleSet ruleSet;
 
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Plan> plans;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FixedPlan> fixedPlans;
     // 기타 맵핑 부분 추가
 
 }

--- a/src/main/java/com/likelion/commit/repository/DiaryRepository.java
+++ b/src/main/java/com/likelion/commit/repository/DiaryRepository.java
@@ -1,0 +1,13 @@
+package com.likelion.commit.repository;
+
+import com.likelion.commit.entity.Diary;
+import com.likelion.commit.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    Diary findByUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/com/likelion/commit/repository/FixedPlanRepository.java
+++ b/src/main/java/com/likelion/commit/repository/FixedPlanRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Repository
 public interface FixedPlanRepository extends JpaRepository<FixedPlan, Long> {
-    List<FixedPlan> findByDateAndUser_Email(LocalDate date, String email);
+    List<FixedPlan> findByUser_EmailAndIsWeekend(String email, boolean isWeekend);
 
-    List<FixedPlan> findByUserAndDateGreaterThan(User user, LocalDate date);
+//    List<FixedPlan> findByUserAndDateGreaterThan(User user, LocalDate date);
 }

--- a/src/main/java/com/likelion/commit/repository/FixedPlanRepository.java
+++ b/src/main/java/com/likelion/commit/repository/FixedPlanRepository.java
@@ -1,0 +1,19 @@
+package com.likelion.commit.repository;
+
+import com.likelion.commit.entity.FixedPlan;
+import com.likelion.commit.entity.Plan;
+import com.likelion.commit.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface FixedPlanRepository extends JpaRepository<FixedPlan, Long> {
+    List<FixedPlan> findByDateAndUser_Email(LocalDate date, String email);
+
+    List<FixedPlan> findByUserAndDateGreaterThan(User user, LocalDate date);
+}

--- a/src/main/java/com/likelion/commit/repository/PlanRepository.java
+++ b/src/main/java/com/likelion/commit/repository/PlanRepository.java
@@ -1,6 +1,7 @@
 package com.likelion.commit.repository;
 
 import com.likelion.commit.entity.Plan;
+import com.likelion.commit.entity.PlanStatus;
 import com.likelion.commit.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,5 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     List<Plan> findByDateAndUser_Email(LocalDate date, String email);
     @Query("SELECT p FROM Plan p WHERE p.date > :currentDate AND p.user.email = :email ORDER BY p.date ASC")
     List<Plan> findUpcomingPlans(@Param("currentDate") LocalDate currentDate, @Param("email") String email);
+    List<Plan> findByUser_EmailAndDateBetween(String email, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/likelion/commit/repository/PlanRepository.java
+++ b/src/main/java/com/likelion/commit/repository/PlanRepository.java
@@ -1,0 +1,21 @@
+package com.likelion.commit.repository;
+
+import com.likelion.commit.entity.Plan;
+import com.likelion.commit.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+    Optional<Plan> findById(Long id);
+    List<Plan> findByDateAndUser_Email(LocalDate date, String email);
+    @Query("SELECT p FROM Plan p WHERE p.date > :currentDate AND p.user.email = :email ORDER BY p.date ASC")
+    List<Plan> findUpcomingPlans(@Param("currentDate") LocalDate currentDate, @Param("email") String email);
+}

--- a/src/main/java/com/likelion/commit/repository/TimeTableRepository.java
+++ b/src/main/java/com/likelion/commit/repository/TimeTableRepository.java
@@ -1,0 +1,12 @@
+package com.likelion.commit.repository;
+
+import com.likelion.commit.entity.TimeTable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TimeTableRepository extends JpaRepository<TimeTable, Long> {
+
+    List<TimeTable> findByUser_IdAndDate(Long userId, LocalDate localDate);
+}

--- a/src/main/java/com/likelion/commit/service/DiaryService.java
+++ b/src/main/java/com/likelion/commit/service/DiaryService.java
@@ -1,0 +1,33 @@
+package com.likelion.commit.service;
+
+import com.likelion.commit.dto.request.DiaryDateRequestDto;
+import com.likelion.commit.dto.request.DiaryRequestDto;
+import com.likelion.commit.dto.response.DiaryResponseDto;
+import com.likelion.commit.entity.Diary;
+import com.likelion.commit.entity.User;
+import com.likelion.commit.gloabal.exception.CustomException;
+import com.likelion.commit.gloabal.response.ErrorCode;
+import com.likelion.commit.repository.DiaryRepository;
+import com.likelion.commit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryService {
+    private final DiaryRepository diaryRepository;
+    private final UserRepository userRepository;
+
+
+    public DiaryResponseDto getDiary(String email, DiaryDateRequestDto diaryDateRequestDto){
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NO_USER_DATA_REGISTERED));
+
+        Diary diary = diaryRepository.findByUserAndDate(user, diaryDateRequestDto.getDate());
+
+        return DiaryResponseDto.from(diary);
+    }
+}

--- a/src/main/java/com/likelion/commit/service/PlanService.java
+++ b/src/main/java/com/likelion/commit/service/PlanService.java
@@ -1,0 +1,351 @@
+package com.likelion.commit.service;
+
+
+import com.likelion.commit.dto.request.*;
+import com.likelion.commit.dto.response.PlanResponseDto;
+import com.likelion.commit.dto.response.TimeTableResponseDto;
+import com.likelion.commit.entity.FixedPlan;
+import com.likelion.commit.entity.Plan;
+import com.likelion.commit.entity.PlanStatus;
+import com.likelion.commit.entity.User;
+import com.likelion.commit.repository.FixedPlanRepository;
+import com.likelion.commit.repository.PlanRepository;
+import com.likelion.commit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanService {
+    private final PlanRepository planRepository;
+    private final UserRepository userRepository;
+    private final FixedPlanRepository fixedPlanRepository;
+
+
+    public void createDefaultFixedPlans(User user) {
+
+            // 주말 FixedPlans
+            createFixedPlan(user,true, "02:00", "10:00", "수면시간");
+            createFixedPlan(user,true, "10:00", "11:00", "아침식사");
+            createFixedPlan(user,true, "14:00", "15:00", "점심식사");
+            createFixedPlan(user,true, "19:00", "20:00", "저녁식사");
+
+            // 평일 FixedPlans
+            createFixedPlan(user,false, "00:00", "07:00", "수면시간");
+            createFixedPlan(user, false, "08:00", "09:00", "아침식사");
+            createFixedPlan(user, false, "13:00", "14:00", "점심식사");
+            createFixedPlan(user, false, "17:30", "18:30", "저녁식사");
+
+    }
+
+    private void createFixedPlan(User user, boolean isWeekend, String startTime, String endTime, String content) {
+        FixedPlan fixedPlan = new FixedPlan();
+        fixedPlan.setUser(user);
+        fixedPlan.setStartTime(LocalTime.parse(startTime));
+        fixedPlan.setEndTime(LocalTime.parse(endTime));
+        fixedPlan.setWeekend(isWeekend);
+        fixedPlan.setContent(content);
+
+        fixedPlanRepository.save(fixedPlan);
+    }
+
+
+    @Transactional
+    public List<PlanResponseDto> createPlans(String email,
+                                             List<CreatePlanRequestDto> createPlanRequestDtoList) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        List<Plan> plans = createPlanRequestDtoList.stream().map(dto -> {
+            Plan plan = dto.toEntity();
+            plan.setUser(user);
+            return plan;
+        }).collect(Collectors.toList());
+
+        List<Plan> savedPlan = planRepository.saveAll(plans);
+
+        return savedPlan.stream()
+                .map(PlanResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+
+    @Transactional
+    public void updatePlans(String email, List<UpdatePlanRequestDto> updatePlanRequestDtos) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        List<Plan> plans = updatePlanRequestDtos.stream().map(dto -> {
+            Plan plan = planRepository.findById(dto.getPlanId()).orElseThrow(() -> new NoSuchElementException("일정을 찾을 수 없습니다."));
+            plan.update(dto);
+            return plan;
+        }).collect(Collectors.toList());
+
+        List<Plan> savedPlan = planRepository.saveAll(plans);
+    }
+
+    @Transactional
+    public void deletePlans(String email, List<DeletePlanRequestDto> deletePlanRequestDtos) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        deletePlanRequestDtos.forEach(dto -> {
+            planRepository.deleteById(dto.getPlanId());
+        });
+    }
+
+    @Transactional
+    public void completePlan(String email, Long planId, PlanTimeRequestDto planTimeRequestDto) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        Plan plan = planRepository.findById(planId).orElseThrow(() -> new NoSuchElementException("일정을 찾을 수 없습니다."));
+
+
+
+        if (plan.getUser().getEmail().equals(user.getEmail())) {
+            // 상태가 null이면 COMPLETE로 설정
+            if (plan.getStatus() == null) {
+                plan.setStatus(PlanStatus.COMPLETE);
+            }
+
+            if (plan.getStatus().equals(PlanStatus.DELAYED)) {
+                planRepository.deleteById(plan.getChildPlan());
+                plan.setChildPlan(null);
+                plan.setDelayed(false);
+            }
+            plan.setStartTime(planTimeRequestDto.startTime);
+            plan.setEndTime(planTimeRequestDto.endTime);
+            plan.setStatus(PlanStatus.COMPLETE);
+            plan.setComplete(true);
+        }
+    }
+
+    @Transactional
+    public void cancelPlan(String email, Long planId) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        Plan plan = planRepository.findById(planId).orElseThrow(() -> new NoSuchElementException("일정을 찾을 수 없습니다."));
+
+
+
+        if (plan.getUser().getEmail().equals(user.getEmail())) {
+            if (plan.getStatus() == null) {
+                plan.setStatus(PlanStatus.CANCELED);
+            }
+            if (plan.getStatus().equals(PlanStatus.DELAYED)) {
+                planRepository.deleteById(plan.getChildPlan());
+                plan.setChildPlan(null);
+                plan.setDelayed(false);
+            }
+            plan.setStatus(PlanStatus.CANCELED);
+            plan.setComplete(false);
+        }
+    }
+
+    @Transactional
+    public void delayPlan(String email, Long planId, DelayPlanRequestDto delayPlanRequestDto) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        Plan plan = planRepository.findById(planId).orElseThrow(() -> new NoSuchElementException("일정을 찾을 수 없습니다."));
+
+
+
+        if (plan.getUser().getEmail().equals(user.getEmail())) {
+            plan.setStatus(PlanStatus.DELAYED);
+            plan.setDelayed(true);
+            plan.setComplete(false);
+
+            Plan childPlan = Plan.builder()
+                    .date(delayPlanRequestDto.getDelayedDate())
+                    .content(plan.getContent())
+                    .priority(plan.getPriority())
+                    .type(plan.getType())
+                    .user(user)
+                    .build();
+
+            planRepository.save(childPlan);
+
+            plan.setChildPlan(childPlan.getId());
+
+            planRepository.save(plan);
+        }
+    }
+
+
+    @Transactional
+    public void updateAddedTime(String email, Long planId, PlanTimeRequestDto planTimeRequestDto) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        Plan plan = planRepository.findById(planId).orElseThrow(() -> new NoSuchElementException("일정을 찾을 수 없습니다."));
+
+        if (plan.getUser().getEmail().equals(user.getEmail())) {
+            plan.setStartTime(planTimeRequestDto.getStartTime());
+            plan.setEndTime(planTimeRequestDto.getEndTime());
+        }
+    }
+
+//    @Transactional
+//    public void updateFixedTime(String email, Long fixedPlanId, PlanTimeRequestDto planTimeRequestDto) {
+//        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+//        FixedPlan existingFixedPlan = fixedPlanRepository.findById(fixedPlanId).orElseThrow(() -> new NoSuchElementException("일정을 찾을 수 없습니다."));
+//
+//        LocalDate changeDate = LocalDate.now();    // 지금 기준 변경
+//        LocalDateTime newStartTime = planTimeRequestDto.getStartTime();
+//        LocalDateTime newEndTime = planTimeRequestDto.getEndTime();
+//
+//
+//        // FixedPlan의 날짜가 변경된 날짜와 동일하거나 이후인 경우에만 업데이트
+//        if (existingFixedPlan.getDate().isAfter(changeDate.minusDays(1))) {
+//            // 변경된 날짜 이후의 FixedPlan들을 조회
+//            List<FixedPlan> fixedPlansToUpdate = fixedPlanRepository.findByUserAndDateGreaterThan(user, changeDate.minusDays(1));
+//
+//            for (FixedPlan fixedPlan : fixedPlansToUpdate) {
+//                // 기존 FixedPlan의 날짜가 변경된 날짜와 동일하거나 이후인 경우에만 업데이트
+//                if (fixedPlan.getDate().isEqual(changeDate) || fixedPlan.getDate().isAfter(changeDate)) {
+//                    fixedPlan.setStartTime(newStartTime);
+//                    fixedPlan.setEndTime(newEndTime);
+//                    fixedPlanRepository.save(fixedPlan);
+//                }
+//            }
+//        }
+//        // 변경된 FixedPlan의 시작과 끝 시간을 업데이트
+//        existingFixedPlan.setStartTime(newStartTime);
+//        existingFixedPlan.setEndTime(newEndTime);
+//        fixedPlanRepository.save(existingFixedPlan);
+//
+//    }
+
+    public List<PlanResponseDto> getPlans(String email, PlanDateRequestDto planDateRequestDto) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        List<Plan> plans = planRepository.findByDateAndUser_Email(planDateRequestDto.getDate(), email);
+        return PlanResponseDto.from(plans);
+    }
+
+
+    @Transactional
+    public List<TimeTableResponseDto> getTimeTable(String email, PlanDateRequestDto planDateRequestDto) {
+        LocalDate date = planDateRequestDto.getDate();
+
+        // 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        // FixedPlan 조회
+        List<FixedPlan> fixedPlans = fixedPlanRepository.findByDateAndUser_Email(date, email);
+
+
+        // 로그 추가
+        System.out.println("FixedPlans: " + fixedPlans);
+
+        // 모든 Plan을 조회
+        List<Plan> plans = planRepository.findByDateAndUser_Email(date, email);
+
+        // 로그 추가
+        System.out.println("Plans: " + plans);
+
+        // 요일을 판단하여 주말인지 평일인지 결정합니다.
+        boolean isWeekend = date.getDayOfWeek() == DayOfWeek.SATURDAY || date.getDayOfWeek() == DayOfWeek.SUNDAY;
+
+        // FixedPlan을 필터링하고 DTO로 변환합니다.
+        List<TimeTableResponseDto> fixedPlanDtos = fixedPlans.stream()
+                .filter(fp -> fp.isWeekend() == isWeekend)
+                .map(fp -> TimeTableResponseDto.builder()
+                        .fixedPlanId(fp.getId())
+                        .startTime(fp.getStartTime())
+                        .endTime(fp.getEndTime())
+                        .isWeekend(fp.isWeekend())
+                        .content(fp.getContent())
+                        .userId(fp.getUser().getId())
+                        .isFixed(true)
+                        .priority(0)
+                        .build())
+                .collect(Collectors.toList());
+
+        // Plan을 필터링하고 DTO로 변환합니다.
+        List<TimeTableResponseDto> planDtos = plans.stream()
+                .filter(p -> p.getStatus() == PlanStatus.COMPLETE && p.getStartTime() != null && p.getEndTime() != null)
+                .map(p -> TimeTableResponseDto.builder()
+                        .planId(p.getId())
+                        .startTime(p.getStartTime())
+                        .endTime(p.getEndTime())
+                        .isWeekend(false)
+                        .content(p.getContent())
+                        .userId(p.getUser().getId())
+                        .isFixed(false)
+                        .priority(p.getPriority())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 두 리스트를 결합합니다.
+        List<TimeTableResponseDto> allDtos = new ArrayList<>();
+        allDtos.addAll(fixedPlanDtos);
+        allDtos.addAll(planDtos);
+
+        // 시작 시간 기준으로 정렬합니다.
+        return allDtos.stream()
+                .sorted(Comparator.comparing(TimeTableResponseDto::getStartTime, Comparator.nullsLast(Comparator.naturalOrder())))
+                .collect(Collectors.toList());
+    }
+
+
+
+
+
+
+
+    @Transactional
+    public List<PlanResponseDto> getUpcomingPlans(String email) {
+        LocalDate currentDate = LocalDate.now();
+        List<Plan> plans = planRepository.findUpcomingPlans(currentDate, email);
+
+        return plans.stream()
+                .limit(3) // 가까운 3개의 일정만 가져오기
+                .map(PlanResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+
+
+    @Transactional
+    public List<PlanResponseDto> createCalendarPlans(String email, CalendarPlanRequestDto calendarPlanRequestDto){
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        LocalDate startDate = calendarPlanRequestDto.getStartDate();
+        LocalDate endDate = calendarPlanRequestDto.getEndDate();
+
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("시작일자가 종료일자보다 나중일 수 없습니다.");
+        }
+
+
+
+        List<Plan> plans = new ArrayList<>();
+
+        while(!startDate.isAfter(endDate)){
+            Plan plan = Plan.builder()
+                    .content(calendarPlanRequestDto.getContent())
+                    .type(calendarPlanRequestDto.getType())
+                    .user(user)
+                    .priority(1)     // A로 고정
+                    .type(calendarPlanRequestDto.getType())
+                    .date(startDate)
+                    .build();
+
+            plans.add(plan);
+
+            startDate = startDate.plusDays(1);
+        }
+        planRepository.saveAll(plans);
+
+        return PlanResponseDto.from(plans);
+    }
+
+
+}

--- a/src/main/java/com/likelion/commit/service/RuleSetService.java
+++ b/src/main/java/com/likelion/commit/service/RuleSetService.java
@@ -1,9 +1,9 @@
 package com.likelion.commit.service;
 
 
-import com.likelion.commit.dto.CreateRuleSetRequestDto;
-import com.likelion.commit.dto.RuleSetResponseDto;
-import com.likelion.commit.dto.UpdateRuleSetRequestDto;
+import com.likelion.commit.dto.request.CreateRuleSetRequestDto;
+import com.likelion.commit.dto.response.RuleSetResponseDto;
+import com.likelion.commit.dto.request.UpdateRuleSetRequestDto;
 import com.likelion.commit.entity.RuleSet;
 import com.likelion.commit.entity.User;
 import com.likelion.commit.repository.RuleSetRepository;

--- a/src/main/java/com/likelion/commit/service/UserService.java
+++ b/src/main/java/com/likelion/commit/service/UserService.java
@@ -1,18 +1,18 @@
 package com.likelion.commit.service;
 
 
-import com.likelion.commit.dto.CreateUserRequestDto;
-import com.likelion.commit.dto.UpdatePasswordRequestDto;
-import com.likelion.commit.dto.UserResponseDto;
+import com.likelion.commit.dto.request.CreateUserRequestDto;
+import com.likelion.commit.dto.request.UpdatePasswordRequestDto;
+import com.likelion.commit.dto.response.UserResponseDto;
 import com.likelion.commit.entity.User;
+import com.likelion.commit.gloabal.exception.CustomException;
+import com.likelion.commit.gloabal.response.ErrorCode;
+import com.likelion.commit.repository.FixedPlanRepository;
 import com.likelion.commit.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.security.InvalidParameterException;
-import java.util.NoSuchElementException;
 
 @Slf4j
 @Service
@@ -20,19 +20,23 @@ import java.util.NoSuchElementException;
 @Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
+    private final FixedPlanRepository fixedPlanRepository;
 //    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    private final PlanService planService;
+
 
     @Transactional
     public long createUser(CreateUserRequestDto createUserRequestDto){
         User user = createUserRequestDto.toEntity(/*passwordEncoder*/);
         userRepository.save(user);
-
+        planService.createDefaultFixedPlans(user);
         return user.getId();
     }
 
     @Transactional
     public void updatePassword(String email, UpdatePasswordRequestDto updatePasswordRequestDto){
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NO_USER_DATA_REGISTERED));
         user.setPassword(updatePasswordRequestDto.getNewPassword());
 
 //        if(passwordEncoder.matches(user.getPassword(), updatePasswordRequestDto.getCurrentPassword())) {
@@ -45,12 +49,12 @@ public class UserService {
 
     @Transactional
     public void deleteUser(String email){
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NO_USER_DATA_REGISTERED));
         userRepository.deleteById(user.getId());
     }
 
     public UserResponseDto getUser(String email){
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NO_USER_DATA_REGISTERED));
         return UserResponseDto.from(user);
     }
 }


### PR DESCRIPTION
[이슈 번호]
#5

[내용]
API 명세서에 있는 API 작성 및 보완

1. 메인화면
- 오늘의 일정에는 추가된 일정들만 조회
- 완료(시간설정), 미루기(연기날짜), 취소
- 타임 테이블 : 고정일정 + 추가된 일정 중 시간 설정 된것들.
- 타임테이블에서 시간변경
- 날짜별 일정 및 타임테이블 조회
- 앞으로의 일정

2.  일정표 확인 및 수정 화면
- 타임테이블 조회
- 일정 조회 : 메인화면이랑 동일
- 일정 추가, 수정, 삭제, 조회
- 고정 테이블 조회, 수정


3. 캘린더 화면
- 일정 추가(우선순위 제외) 
- 월 별 일정 조회

4. 오늘 하루 마무리하기
- 하루 마무리 : 기록사항 + date 받고 타임테이블 저장
- 기록사항 조회
- 일정 조회
- 타임테이블 조회